### PR TITLE
Add new ADD_TARGET_BLANK env for enabling new tab for container links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ FROM nginx:1.21-alpine
 COPY --from=docker-gen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 COPY ./app /app
 
-# Set default environment variable values
-ENV ADD_TARGET_BLANK=false
-
 #ensure docker-entrypoint is executable
 RUN chmod +x /app/docker-entrypoint.sh 
 COPY ./static/ /usr/share/nginx/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM nginx:1.21-alpine
 
 COPY --from=docker-gen /usr/local/bin/docker-gen /usr/local/bin/docker-gen
 COPY ./app /app
+
+# Set default environment variable values
+ENV ADD_TARGET_BLANK=false
+
 #ensure docker-entrypoint is executable
 RUN chmod +x /app/docker-entrypoint.sh 
 COPY ./static/ /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The `traefik-home` container can be configured using the following optional labe
 | traefik-home.show-footer | Whether to show footer on the home page | true |
 | traefik-home.show-status-dot | Whether to show green/red status dot near the container name | true |
 | traefik-home.sort-by | Container list sort order. Supported values are "default" (container creation date) or "name" | "default" |
+| traefik-home.open-link-in-new-tab | whether to open the container link in a new tab using the target attribute. Supports "true" or "false"  | false |
 
 ## Labels to configure containers
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ services:
     container_name: traefik-home
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - ADD_TARGET_BLANK=false # true will open container links to new tab
     labels:
       - traefik.enable="true"
       - traefik.http.routers.traefik-home.rule="Host(`home.example.com`)"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ services:
     container_name: traefik-home
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      - ADD_TARGET_BLANK=false # true will open container links to new tab
     labels:
       - traefik.enable="true"
       - traefik.http.routers.traefik-home.rule="Host(`home.example.com`)"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `traefik-home` container can be configured using the following optional labe
 | traefik-home.show-footer | Whether to show footer on the home page | true |
 | traefik-home.show-status-dot | Whether to show green/red status dot near the container name | true |
 | traefik-home.sort-by | Container list sort order. Supported values are "default" (container creation date) or "name" | "default" |
-| traefik-home.open-link-in-new-tab | whether to open the container link in a new tab using the target attribute. Supports "true" or "false"  | false |
+| traefik-home.open-link-in-new-tab | Whether to open services link in a new tab | false |
 
 ## Labels to configure containers
 

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
 
+# Path to your home.tmpl file
+HOME_TMPL_PATH="/app/home.tmpl"
+
+# Check if ADD_TARGET_BLANK is set to "true" and if target="_blank" is not already present
+if [ "$ADD_TARGET_BLANK" = "true" ] && ! grep -q 'class="text-decoration-none text-secondary" target="_blank"' "$HOME_TMPL_PATH"; then
+    sed -i 's/class="text-decoration-none text-secondary"/class="text-decoration-none text-secondary" target="_blank"/g' "$HOME_TMPL_PATH"
+fi
+
 nginx&
 docker-gen -watch -include-stopped /app/home.tmpl /usr/share/nginx/html/index.html

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -1,12 +1,4 @@
 #!/bin/sh
 
-# Path to your home.tmpl file
-HOME_TMPL_PATH="/app/home.tmpl"
-
-# Check if ADD_TARGET_BLANK is set to "true" and if target="_blank" is not already present
-if [ "$ADD_TARGET_BLANK" = "true" ] && ! grep -q 'class="text-decoration-none text-secondary" target="_blank"' "$HOME_TMPL_PATH"; then
-    sed -i 's/class="text-decoration-none text-secondary"/class="text-decoration-none text-secondary" target="_blank"/g' "$HOME_TMPL_PATH"
-fi
-
 nginx&
 docker-gen -watch -include-stopped /app/home.tmpl /usr/share/nginx/html/index.html

--- a/app/home.tmpl
+++ b/app/home.tmpl
@@ -2,6 +2,11 @@
 {{ $show_footer := or (index $home_container.Labels "traefik-home.show-footer") "true" | parseBool }}
 {{ $show_status_dot := or (index $home_container.Labels "traefik-home.show-status-dot") "true" | parseBool }}
 {{ $sort_by := or (index $home_container.Labels "traefik-home.sort-by") "default" }}
+{{ $link_in_new_tab := or (index $home_container.Labels "traefik-home.open-link-in-new-tab") "false" | parseBool }}
+{{ $target := "_self" }}
+{{ if $link_in_new_tab }}
+    {{ $target = "_blank" }}
+{{ end }}
 
 <!DOCTYPE html>
 <html lang="en" class="min-vh-100">
@@ -154,7 +159,7 @@
                 {{ end }}
 
                 <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 col-6 mt-4 mx-xl-2">
-                    <a class="text-decoration-none text-secondary" href="{{ print $protocol "://" $host $path }}">
+                    <a class="text-decoration-none text-secondary" target="{{ $target }}" href="{{ print $protocol "://" $host $path }}">
                         <div class="row-cols-1 text-center">
                             {{/* if icon is set for this docker image then display it, otherwise use a generic icon made up by the first 2 letters */}}
                             {{ $icon := index $container.Labels "traefik-home.icon"}}


### PR DESCRIPTION
Added new ENV variable to be able to switch between opening the containers links in new tab or same tab window.
I have updated read me for updated docker-compose.yml file to how to use it.