### PR TITLE
New entrypoint labels added

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The `traefik-home` container can be configured using the following optional labe
 | traefik-home.show-status-dot | Whether to show green/red status dot near the container name | true |
 | traefik-home.sort-by | Container list sort order. Supported values are "default" (container creation date) or "name" | "default" |
 | traefik-home.open-link-in-new-tab | Whether to open services link in a new tab | false |
+| traefik-home.https-entrypoints | List of https entrypoints to show. <br> Example: `traefik-home.https-entrypoints=websecure1,websecure2` | websecure |
+| traefik-home.http-entrypoints | List of http entrypoints to show. <br> Example: `traefik-home.http-entrypoints=websecure1,websecure2` | web |
 
 ## Labels to configure containers
 
@@ -75,7 +77,6 @@ Home will use the following `traefik` labels to generate the HTML page.
 | Label  | Description |
 | --- | --- |
 | traefik.http.routers.\<service\>.rule | Domain and path used by Home to generate the link to the service |
-| traefik.http.routers.\<service\>.entrypoints | Only `web` or `websecure` entrypoints are shown |
 | traefik.enable | Only explicitly enabled container are shown on the homepage |
 
 <details>

--- a/app/home.tmpl
+++ b/app/home.tmpl
@@ -8,6 +8,13 @@
     {{ $target = "_blank" }}
 {{ end }}
 
+
+{{/* Read HTTP and HTTPS entrypoints from labels or use defaults */}}
+{{ $http_entrypoints := split (or (index $home_container.Labels "traefik-home.http-entrypoints") "web") "," }}
+{{ $https_entrypoints := split (or (index $home_container.Labels "traefik-home.https-entrypoints") "websecure") "," }}
+
+
+
 <!DOCTYPE html>
 <html lang="en" class="min-vh-100">
 <head>
@@ -146,17 +153,84 @@
                     {{ $path = regexReplaceAll ".*?Path(Prefix)?\\(\\`([a-z0-9-\\/]+)\\`\\).*" $host_rule "$2" }}
                 {{end}}
 
-                {{ $entrypoint_label := print "traefik.http.routers." $service_name ".entrypoints" }}
-                {{ $entrypoint := index $container.Labels $entrypoint_label }}
-                {{ $protocol := "" }}
-                {{ if eq $entrypoint "websecure" }}
-                    {{ $protocol = "https" }}
-                {{ else if eq $entrypoint "web" }}
-                    {{ $protocol = "http" }}
-                {{ else }}
-                    {{/* entrypoint not supported */}}
+            {{ $entrypoint_label := print "traefik.http.routers." $service_name ".entrypoints" }}
+            {{ $entrypoints := index $container.Labels $entrypoint_label }}
+            {{ $protocol := "" }}
+
+
+
+
+
+
+            {{ $entrypoint_label := print "traefik.http.routers." $service_name ".entrypoints" }}
+            {{ $entrypoints := index $container.Labels $entrypoint_label }}
+            {{ $protocol := "" }}
+
+            {{/* Check if entrypoints label is defined and split into an array */}}
+            {{ if $entrypoints }}
+                {{ $entrypoints_list := split $entrypoints "," }}
+
+                {{/* Flag to determine if a matching entrypoint was found */}}
+                {{ $entrypoint_found := false }}
+
+                {{/* Check if entrypoint is in the HTTPS entrypoints list */}}
+                {{ range $entrypoints_list }}
+                    {{ $current_entrypoint := . }}
+                    {{ $is_https := false }}
+                    {{ $is_http := false }}
+
+                    {{ range $https_entrypoints }}
+                        {{ if eq $current_entrypoint . }}
+                            {{ $is_https = true }}
+                            {{break}}
+                        {{ end }}
+                    {{ end }}
+
+                    {{ if $is_https }}
+                        {{ $protocol = "https" }}
+                        {{ $entrypoint_found = true }}
+                        {{break}}
+                    {{ else }}
+                        {{ range $http_entrypoints }}
+                            {{ if eq $current_entrypoint . }}
+                                {{ $is_http = true }}
+                                {{break}}
+                            {{ end }}
+                        {{ end }}
+
+                        {{ if $is_http }}
+                            {{ $protocol = "http" }}
+                            {{ $entrypoint_found = true }}
+                            {{break}}
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+
+                {{/* Skip container if no supported entrypoint was found */}}
+                {{ if not $entrypoint_found }}
                     {{continue}}
                 {{ end }}
+            {{ else }}
+                {{/* Skip container if entrypoints label is not defined */}}
+                {{continue}}
+            {{ end }}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
                 <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 col-6 mt-4 mx-xl-2">
                     <a class="text-decoration-none text-secondary" target="{{ $target }}" href="{{ print $protocol "://" $host $path }}">

--- a/app/home.tmpl
+++ b/app/home.tmpl
@@ -8,12 +8,9 @@
     {{ $target = "_blank" }}
 {{ end }}
 
-
 {{/* Read HTTP and HTTPS entrypoints from labels or use defaults */}}
 {{ $http_entrypoints := split (or (index $home_container.Labels "traefik-home.http-entrypoints") "web") "," }}
 {{ $https_entrypoints := split (or (index $home_container.Labels "traefik-home.https-entrypoints") "websecure") "," }}
-
-
 
 <!DOCTYPE html>
 <html lang="en" class="min-vh-100">
@@ -157,11 +154,6 @@
             {{ $entrypoints := index $container.Labels $entrypoint_label }}
             {{ $protocol := "" }}
 
-
-
-
-
-
             {{ $entrypoint_label := print "traefik.http.routers." $service_name ".entrypoints" }}
             {{ $entrypoints := index $container.Labels $entrypoint_label }}
             {{ $protocol := "" }}
@@ -214,23 +206,6 @@
                 {{/* Skip container if entrypoints label is not defined */}}
                 {{continue}}
             {{ end }}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
                 <div class="col-xl-2 col-lg-3 col-md-4 col-sm-6 col-6 mt-4 mx-xl-2">
                     <a class="text-decoration-none text-secondary" target="{{ $target }}" href="{{ print $protocol "://" $host $path }}">

--- a/app/home.tmpl
+++ b/app/home.tmpl
@@ -154,10 +154,6 @@
             {{ $entrypoints := index $container.Labels $entrypoint_label }}
             {{ $protocol := "" }}
 
-            {{ $entrypoint_label := print "traefik.http.routers." $service_name ".entrypoints" }}
-            {{ $entrypoints := index $container.Labels $entrypoint_label }}
-            {{ $protocol := "" }}
-
             {{/* Check if entrypoints label is defined and split into an array */}}
             {{ if $entrypoints }}
                 {{ $entrypoints_list := split $entrypoints "," }}
@@ -182,19 +178,11 @@
                         {{ $protocol = "https" }}
                         {{ $entrypoint_found = true }}
                         {{break}}
-                    {{ else }}
-                        {{ range $http_entrypoints }}
-                            {{ if eq $current_entrypoint . }}
-                                {{ $is_http = true }}
-                                {{break}}
-                            {{ end }}
-                        {{ end }}
-
-                        {{ if $is_http }}
-                            {{ $protocol = "http" }}
-                            {{ $entrypoint_found = true }}
-                            {{break}}
-                        {{ end }}
+                    {{ end }}
+                    {{ if $is_http }}
+                        {{ $protocol = "http" }}
+                        {{ $entrypoint_found = true }}
+                        {{break}}
                     {{ end }}
                 {{ end }}
 


### PR DESCRIPTION
New labels to specify which entrypoints should be displayed. The labels expect an array of Stirngs.
Several entrypoints can therefore be specified per label. (Example see Readme.md)


If a container has one of the specified entrypoints, it is displayed.